### PR TITLE
Fix slashes in "deprecated" tag paths

### DIFF
--- a/Manual/contents/GameMaker_Language/GML_Overview/Variables/Builtin_Global_Variables/health.htm
+++ b/Manual/contents/GameMaker_Language/GML_Overview/Variables/Builtin_Global_Variables/health.htm
@@ -14,7 +14,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">health</span> <span data-conref="..\..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">health</span> <span data-conref="../../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>この変数は<b>グローバルな</b>もので、通常プレイヤーの体力に使用される数値を保持するために使用されます。この変数は<i>GameMakerの</i>旧バージョンからのレガシープロジェクトをサポートするために設計されており、また、GameMakerの旧バージョンからのレガシープロジェクトをサポートする必要があります。 <b><i>新規プロジェクトでは使用しない</i></b>将来的に非推奨となる可能性があるため。</p>
   <p> </p>
   <h4>構文です。</h4>

--- a/Manual/contents/GameMaker_Language/GML_Overview/Variables/Builtin_Global_Variables/lives.htm
+++ b/Manual/contents/GameMaker_Language/GML_Overview/Variables/Builtin_Global_Variables/lives.htm
@@ -14,7 +14,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">lives</span> <span data-conref="..\..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">lives</span> <span data-conref="../../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>この変数は<b>グローバルな</b>スコープで、通常プレイヤーのライフに使用される数値を保持するために使用されます。この変数は<i>GameMakerの</i>旧バージョンからのレガシープロジェクトをサポートするためだけに設計されています。 <b><i>新規プロジェクトでは使用しない</i></b>将来的に非推奨となる可能性があるため。</p>
   <p> </p>
   <h4>構文です。</h4>

--- a/Manual/contents/GameMaker_Language/GML_Overview/Variables/Builtin_Global_Variables/score.htm
+++ b/Manual/contents/GameMaker_Language/GML_Overview/Variables/Builtin_Global_Variables/score.htm
@@ -14,7 +14,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">score</span> <span data-conref="..\..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">score</span> <span data-conref="../../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>この変数は<b>グローバルな</b>もので、通常プレイヤーのスコアに使用される数値を保持するために使用されます。この変数は<i>GameMakerの</i>以前のバージョンからのレガシープロジェクトをサポートするためだけに設計されています。 <b><i>新規プロジェクトでは使用しない</i></b>将来的に非推奨となる可能性があるため。</p>
   <p> </p>
   <h4>構文です。</h4>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Fonts/font_get_first.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Fonts/font_get_first.htm
@@ -14,7 +14,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">font_get_first</span> <span data-conref="..\..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">font_get_first</span> <span data-conref="../../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p><span data-keyref="GameMaker Name">GameMakerで</span> <span class="notranslate">font</span> を定義するとき、含める文字の範囲を定義することができます。これは、<span class="notranslate">font</span> 自体は実際にはゲームに含まれず（法的な理由から）、その<i>イメージは</i>
     <span class="notranslate">font</span> は<span class="notranslate">texture</span> ページに含まれており、あなたのゲームではそれが使用されます (他のグラフィック<span class="notranslate">asset</span> と同様です)。このため、使用する文字数は最小限に抑え、以下の範囲のみを指定する必要があります。
     <span class="notranslate">texture</span> メモリを可能な限り最適に保つために、あなたのゲームが必要とするものです。この関数は、<span class="notranslate">font</span> <span class="notranslate">asset</span> がゲームに追加されたときに使用された開始文字（ASCII値）を見つけるために使用することができます。</p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Instances/instance_change.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Instances/instance_change.htm
@@ -15,7 +15,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">instance_change</span> <span data-conref="..\..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">instance_change</span> <span data-conref="../../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>この関数を使用して、あるインスタンス<span class="notranslate">object</span> を別のインスタンス<span class="notranslate">object</span> に変更し、その際に最初のインスタンスの Destroy と Clean Up Event と新しいインスタンスの Create Event を実行するかどうかを決定することができる。この場合、爆弾の Destroy イベントと Clean Up イベント、および爆発の Create イベントを実行させたいので、「perf」引数はおそらく true になります。</p>
   <p>インスタンスを変更するということは、そのインスタンスに対して次のステップまで何もしないこと、特に変数にアクセスしようとするとエラーが発生することを意味します。基本的に、インスタンスを変更しても、現在のステップが終了するまで実際には使用できないので、そのインスタンスが含む変数に直接アクセスすることはできません（たとえば、 <span class="inline">obj_Changed.x</span> を呼び出すなど）。</p>
   <p class="note"><b>警告!物</b>理演算が有効なインスタンスを変更した場合、その物理特性は変更先のインスタンスに<b>引き継が</b>れません。そのため、現在のインスタンスの物理状態を新しいインスタンスに「転送」するコードを用意するか、新しいインスタンスの物理プロパティをその作成イベントまたは<span class="notranslate">object</span> エディタで定義しておく必要があります。このため、物理演算が可能なインスタンスにはこの関数を使用せず、むしろ <span style="font-size:1px;"><span class="inline">instance_destroy()</span></span>および<span><span style="font-size:1px;"><span class="inline">instance_create_layer()</span></span></span>。</p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Objects/Object_Events/event_action.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Objects/Object_Events/event_action.htm
@@ -14,7 +14,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">event_action</span> <span data-conref="..\..\..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">event_action</span> <span data-conref="../../../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>この<b>読み取り専用の</b>変数は、現在実行中のアクションのインデックスを返す。以前のバージョンの<span class="notranslate">GameMaker</span> では 0 から始まる。 しかし、<span data-keyref="GameMaker Name">GameMaker</span> ではこの<b>変数は廃止 </b>されている。レガシーサポートのために残されており、実行速度を向上させるためにすべてのアクションが連結されるため、<b>常に0を返す</b>ことになる。</p>
   <p> </p>
   <h4>構文です。</h4>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/room_speed.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/room_speed.htm
@@ -14,7 +14,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">room_speed</span> <span data-conref="..\..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">room_speed</span> <span data-conref="../../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>この変数は、<b>すべての</b> <span class="notranslate">rooms</span> （およびゲーム）の実行速度をゲームフレーム/秒単位で保持します。これはFPS（frames per second<i>）ではなく</i>、<span data-keyref="GameMaker Name">GameMakerが</span>1秒間に維持しようとするゲームステップの数であることに注意。
     秒になります。</p>
   <p class="note"><b>重要!こ</b>の変数はレガシーサポートのためだけに維持されています。この変数はもはや単一の<span class="notranslate">room</span> に対してではなく、ゲーム内のすべての<span class="notranslate">rooms</span> に対して速度を設定するため、使用しないでください。ゲームスピードを変更するには、代わりに関数 <span style="font-size:1px;"><a href="../../General_Game_Control/game_set_speed.htm"><span class="inline">game_set_speed()</span></a></span>.</p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Asynchronous_Functions/Cloud_Saving/cloud_file_save.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Asynchronous_Functions/Cloud_Saving/cloud_file_save.htm
@@ -14,7 +14,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">cloud_file_save</span> <span data-conref="..\..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">cloud_file_save</span> <span data-conref="../../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>この関数は、選択したクラウドサービスにファイルを保存するようコミットします。この関数は一意の<b>ID</b>値を返し、それを適切な非同期イベントで使用して、クラウドサービスからの「コールバック」として返される DS マップを識別する必要があります。クラウドには1つの「データブロブ」しか保存できないため、ファイルにはゲームに必要な<i>すべての</i>情報が含まれていなければなりません。 <a href="cloud_string_save.htm"><span class="inline">cloud_string_save()</span></a>関数を使用します)。説明文は、「Level2, Stage2」のように、保存内容を説明する短い情報（<span class="notranslate">string</span> ）である必要があります。</p>
   <p>返される非同期データの詳細については、関数 <a href="cloud_synchronise.htm"><span class="inline">cloud_synchronise()</span></a>.</p>
   <p> </p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Asynchronous_Functions/Cloud_Saving/cloud_string_save.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Asynchronous_Functions/Cloud_Saving/cloud_string_save.htm
@@ -15,7 +15,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">cloud_string_save</span> <span data-conref="..\..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">cloud_string_save</span> <span data-conref="../../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>この関数は、選択したクラウドサービスに<span class="notranslate">string</span> をコミットし、保管する。この関数は一意の<b>ID</b>値を返し、それを適切な非同期イベントで使用して、クラウドサービスからの「コールバック」として返される DS マップを識別する必要があります。クラウドには1つの「データブロブ」しか保存できないため、<span class="notranslate">string</span> にはゲームに保存する必要がある<i>すべての</i>情報が含まれているはずです。この関数を再度実行すると、以前に保存した値がすべて上書きされます (同様に <a href="cloud_file_save.htm"><span class="inline">cloud_file_save()</span></a>関数を使用します)。説明文は、「Level2, Stage2」のように、保存内容を説明する短い情報（<span class="notranslate">string</span> ）である必要があります。</p>
   <p>返される非同期データの詳細については、関数 <a href="cloud_synchronise.htm"><span class="inline">cloud_synchronise()</span></a>.</p>
   <p> </p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Asynchronous_Functions/Cloud_Saving/cloud_synchronise.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Asynchronous_Functions/Cloud_Saving/cloud_synchronise.htm
@@ -15,7 +15,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">cloud_synchronise</span> <span data-conref="..\..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">cloud_synchronise</span> <span data-conref="../../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>この関数は通常、新しいゲームの開始時に呼び出され、ゲーム起動時にクラウドサービスの現在のステータスを取得するために使用されます。この関数は一意の<b>ID</b>値を返し、これを<a href="../../../../The_Asset_Editors/Object_Properties/Async_Events/Cloud.htm">非同期クラウドイベントで</a>使用して、作成される DS マップから関連情報を取得します。</p>
   <p>この関数は、クラウドにデータを送信し、適切な非同期イベントをトリガーします。このイベントでは、返された <a href="../../../GML_Overview/Variables/Builtin_Global_Variables/async_load.htm"><span class="inline">async_load</span></a>DSマップに以下の値があるかどうか。</p>
   <ul class="colour">
@@ -56,7 +56,7 @@
       <tr>
         <td><span class="notranslate">3</span></td>
         <td>resultString = &quot;GameUploadSuccess&quot;。</td>
-        <td><span class="notranslate">data from <a href="cloud_string_save.htm"><span class="inline">cloud_string_save()</span> または <a href="cloud_file_save.htm"><span class="inline">cloud_file_save()</span></a>がクラウドに正常にアップロードされました</td>
+        <td>data from <a href="cloud_string_save.htm"><span class="inline">cloud_string_save()</span></a> または <a href="cloud_file_save.htm"><span class="inline">cloud_file_save()</span></a>がクラウドに正常にアップロードされました</td>
       </tr>
       <tr>
         <td><span class="notranslate">-n</span></td>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Cameras_And_Display/The_Game_Window/window_device.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Cameras_And_Display/The_Game_Window/window_device.htm
@@ -15,7 +15,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">window_device</span> <span data-conref="..\..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">window_device</span> <span data-conref="../../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>この関数は、現在の d3d デバイス<i>ポインタを</i>返します。このポインタを、(例えば)<span class="notranslate">Windows</span> や<span class="notranslate">macOS</span> の DLL や Dylib に渡すことができます。</p>
   <p class="note"><span class="note">注</span>：この関数は<span data-keyref="GameMaker Name">GameMaker</span>では非推奨となり、次の関数が採用されています。 <a href="../../OS_And_Compiler/os_get_info.htm"><span style="font-size:1px;"><span class="inline">os_get_info()</span></span></a>.</p>
   <p> </p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Debugging/get_integer.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Debugging/get_integer.htm
@@ -15,7 +15,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">get_integer</span> <span data-conref="..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">get_integer</span> <span data-conref="../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>これはカスタムメッセージを表示するポップアップウィンドウを作成し、&quot;Ok &quot;というラベルのついたボタンを表示し、ユーザに整数値を入力するように促します。この関数は入力された整数を返し、何も入力されていない場合はデフォルト値を返します。</p>
   <p class="note"><b><span class="note">注意</span></b>この関数は<span class="notranslate">Windows</span> ターゲット<b>上でのみデバッグ</b>用に使用され、他のすべてのターゲットでは<b>非推奨と</b>なります。</p>
   <p> </p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Debugging/get_string.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Debugging/get_string.htm
@@ -15,7 +15,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">get_string</span> <span data-conref="..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">get_string</span> <span data-conref="../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>これは、標準的なメッセージを表示するポップアップウィンドウを作成し、「Ok」というラベルの付いたボタンで、ユーザーに<span class="notranslate">string</span> を入力するように促します。 この関数は、入力された<span class="notranslate">string</span> を返し<i>、</i>何も入力されていない場合はデフォルト値を返します。</p>
   <p class="note"><b><span class="note">注意</span></b>この関数は<span class="notranslate">Windows</span> ターゲット<b>上でのみデバッグ</b>用に使用され、他のすべてのターゲットでは<b>非推奨と</b>なります。</p>
   <p> </p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Drawing/Particles/effect_create_above.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Drawing/Particles/effect_create_above.htm
@@ -14,7 +14,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">effect_create_above</span> <span data-conref="..\..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">effect_create_above</span> <span data-conref="../../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>この機能を使うと、<span class="notranslate">room</span> のすべてのインスタンスの上に簡単なエフェクトを作成できます（実際には深度 -100000 で作成されます）。エフェクトが <span class="inline">ef_rain</span> または <span class="inline">ef_snow</span> 以外の場合は、エフェクトを作成するための x/y 位置を定義し、サイズを 0、1、2 のいずれかの値で指定します（0 は小、1 は中、2 は大）。</p>
   <p>これらのエフェクトの描画をオン・オフしたり、描画を一時停止したりするには、関数 <a href="Particle_Systems/part_system_automatic_draw.htm"><span class="inline">part_system_automatic_draw()</span></a>と <a href="Particle_Systems/part_system_automatic_update.htm"><span class="inline">part_system_automatic_update()</span></a>をパーティクルシステムインデックスに適切な値で指定します（0は下のエフェクト、1は上のエフェクト）。</p>
   <p>粒子の種類によって利用可能な定数は以下の通りです。</p>
@@ -34,62 +34,62 @@
         <th>商品説明</th>
       </tr>
       <tr>
-        <td><span class="notranslate"><span class="inline">ef_cloud</span></td>
+        <td><span class="inline">ef_cloud</span></td>
         <td style="text-align: center"><img alt="cloud effect example" class="icon" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Drawing/ef_cloud.png" /></td>
         <td><span class="notranslate">An effect that creates random cloud particles of varying sizes</span></td>
       </tr>
       <tr>
-        <td><span class="notranslate"><span class="inline">ef_ellipse</span></td>
+        <td><span class="inline">ef_ellipse</span></td>
         <td style="text-align: center"><img alt="ellipse effect example" class="icon" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Drawing/ef_ellipse.png" /></td>
         <td><span class="notranslate">An effect that creates expanding ellipses</span></td>
       </tr>
       <tr>
-        <td><span class="notranslate"><span class="inline">ef_explosion</span></td>
+        <td><span class="inline">ef_explosion</span></td>
         <td style="text-align: center"><img alt="explosion effect example" class="icon" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Drawing/ef_explosion.png" /></td>
         <td><span class="notranslate">An effect that creates expanding fading explosions</span></td>
       </tr>
       <tr>
-        <td><span class="notranslate"><span class="inline">ef_firework</span></td>
+        <td><span class="inline">ef_firework</span></td>
         <td style="text-align: center"><img alt="firework effect example" class="icon" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Drawing/ef_firework.png" /></td>
         <td><span class="notranslate">An effect that creates multiple small particles to generate a firework explosion</span></td>
       </tr>
       <tr>
-        <td><span class="notranslate"><span class="inline">ef_flare</span></td>
+        <td><span class="inline">ef_flare</span></td>
         <td style="text-align: center"><img alt="flare effect example" class="icon" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Drawing/ef_flare.png" /></td>
         <td><span class="notranslate">An effect that generates a brilliant point that flares up and fades out</span></td>
       </tr>
       <tr>
-        <td><span class="notranslate"><span class="inline">ef_rain</span></td>
+        <td><span class="inline">ef_rain</span></td>
         <td style="text-align: center"><img alt="rain effect example" class="icon" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Drawing/ef_rain.png" /></td>
         <td><span class="notranslate">An effect that generates rain particles coming down from the top of the screen</span></td>
       </tr>
       <tr>
-        <td><span class="notranslate"><span class="inline">ef_ring</span></td>
+        <td><span class="inline">ef_ring</span></td>
         <td style="text-align: center"><img alt="circle effect example" class="icon" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Drawing/ef_ring.png" /></td>
         <td><span class="notranslate">An effect that generates expanding and fading circles</span></td>
       </tr>
       <tr>
-        <td><span class="notranslate"><span class="inline">ef_smoke</span></td>
+        <td><span class="inline">ef_smoke</span></td>
         <td style="text-align: center"><img alt="smoke effect example" class="icon" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Drawing/ef_smoke.png" /></td>
         <td><span class="notranslate">An effect that generates little puffs of smoke</span></td>
       </tr>
       <tr>
-        <td><span class="notranslate"><span class="inline">ef_smokeup</span></td>
+        <td><span class="inline">ef_smokeup</span></td>
         <td style="text-align: center"><img alt="rising smoke effect example" class="icon" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Drawing/ef_smokeup.png" /></td>
         <td><span class="notranslate">An effect that creates a smoke plume that rises up the screen</span></td>
       </tr>
       <tr>
-        <td><span class="notranslate"><span class="inline">ef_snow</span></td>
+        <td><span class="inline">ef_snow</span></td>
         <td style="text-align: center"><img alt="snow effect example" class="icon" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Drawing/ef_snow.png" /></td>
         <td><span class="notranslate">An effect that generates multiple snow particles falling down the screen</span></td>
       </tr>
       <tr>
-        <td><span class="notranslate"><span class="inline">ef_spark</span></td>
+        <td><span class="inline">ef_spark</span></td>
         <td style="text-align: center"><img alt="spark effect example" class="icon" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Drawing/ef_spark.png" /></td>
         <td><span class="notranslate">An effect that generates a small spark</span></td>
       </tr>
       <tr>
-        <td><span class="notranslate"><span class="inline">ef_star</span></td>
+        <td><span class="inline">ef_star</span></td>
         <td style="text-align: center"><img alt="star effect example" class="icon" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Drawing/ef_star.png" /></td>
         <td><span class="notranslate">An effect that generates star particles</span></td>
       </tr>
@@ -108,7 +108,7 @@
       <tr>
         <td><span class="notranslate">kind</span></td>
         <td><span data-keyref="Type_Constant_Effect"><a data-rhwidget="HyperlinkPopover" href="../../../../../GameMaker_Language/GML_Reference/Drawing/Particles/effect_create_above.htm">効果の種類 定数</a></span></td>
-        <td><span class="notranslate">The kind of effect (use one of the constants listed<span> above</span>).</td>
+        <td>The kind of effect (use one of the constants listed<span> above</span>).</td>
       </tr>
       <tr>
         <td><span class="notranslate">x</span></td>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Drawing/Particles/effect_create_below.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Drawing/Particles/effect_create_below.htm
@@ -14,7 +14,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">effect_create_below</span> <span data-conref="..\..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">effect_create_below</span> <span data-conref="../../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>この機能を使うと、<span class="notranslate">room</span> のすべてのインスタンスの下に簡単なエフェクトを作成することができます（実際には 100000 の深さで作成されます）。エフェクトが <span class="inline">ef_rain</span> または <span class="inline">ef_snow</span> 以外の場合は、エフェクトを作成するための x/y 位置を定義し、サイズを 0、1、2 のいずれかの値で指定します。</p>
   <p>これらのエフェクトの描画をオン・オフしたり、描画を一時停止したりするには、関数 <a href="Particle_Systems/part_system_automatic_draw.htm"><span class="inline">part_system_automatic_draw()</span></a>と <a href="Particle_Systems/part_system_automatic_update.htm"><span class="inline">part_system_automatic_update()</span></a>をパーティクルシステムインデックスに適切な値で指定します（0は下のエフェクト、1は上のエフェクト）。</p>
   <p>粒子の種類によって利用可能な定数は以下の通りです。</p>
@@ -26,62 +26,62 @@
         <th>商品説明</th>
       </tr>
       <tr>
-        <td><span class="notranslate"><span class="inline">ef_cloud</span></td>
+        <td><span class="inline">ef_cloud</span></td>
         <td style="text-align: center"><img alt="cloud effect example" class="icon" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Drawing/ef_cloud.png" /></td>
         <td><span class="notranslate">An effect that creates random cloud particles of varying sizes</span></td>
       </tr>
       <tr>
-        <td><span class="notranslate"><span class="inline">ef_ellipse</span></td>
+        <td><span class="inline">ef_ellipse</span></td>
         <td style="text-align: center"><img alt="ellipse effect example" class="icon" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Drawing/ef_ellipse.png" /></td>
         <td><span class="notranslate">An effect that creates expanding ellipses</span></td>
       </tr>
       <tr>
-        <td><span class="notranslate"><span class="inline">ef_explosion</span></td>
+        <td><span class="inline">ef_explosion</span></td>
         <td style="text-align: center"><img alt="explosion effect example" class="icon" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Drawing/ef_explosion.png" /></td>
         <td><span class="notranslate">An effect that creates expanding fading explosions</span></td>
       </tr>
       <tr>
-        <td><span class="notranslate"><span class="inline">ef_firework</span></td>
+        <td><span class="inline">ef_firework</span></td>
         <td style="text-align: center"><img alt="firework effect example" class="icon" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Drawing/ef_firework.png" /></td>
         <td><span class="notranslate">An effect that creates multiple small particles to generate a firework explosion</span></td>
       </tr>
       <tr>
-        <td><span class="notranslate"><span class="inline">ef_flare</span></td>
+        <td><span class="inline">ef_flare</span></td>
         <td style="text-align: center"><img alt="flare effect example" class="icon" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Drawing/ef_flare.png" /></td>
         <td><span class="notranslate">An effect that generates a brilliant point that flares up and fades out</span></td>
       </tr>
       <tr>
-        <td><span class="notranslate"><span class="inline">ef_rain</span></td>
+        <td><span class="inline">ef_rain</span></td>
         <td style="text-align: center"><img alt="rain effect example" class="icon" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Drawing/ef_rain.png" /></td>
         <td><span class="notranslate">An effect that generates rain particles coming down from the top of the screen</span></td>
       </tr>
       <tr>
-        <td><span class="notranslate"><span class="inline">ef_ring</span></td>
+        <td><span class="inline">ef_ring</span></td>
         <td style="text-align: center"><img alt="circle effect example" class="icon" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Drawing/ef_ring.png" /></td>
         <td><span class="notranslate">An effect that generates expanding and fading circles</span></td>
       </tr>
       <tr>
-        <td><span class="notranslate"><span class="inline">ef_smoke</span></td>
+        <td><span class="inline">ef_smoke</span></td>
         <td style="text-align: center"><img alt="smoke effect example" class="icon" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Drawing/ef_smoke.png" /></td>
         <td><span class="notranslate">An effect that generates little puffs of smoke</span></td>
       </tr>
       <tr>
-        <td><span class="notranslate"><span class="inline">ef_smokeup</span></td>
+        <td><span class="inline">ef_smokeup</span></td>
         <td style="text-align: center"><img alt="rising smoke effect example" class="icon" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Drawing/ef_smokeup.png" /></td>
         <td><span class="notranslate">An effect that creates a smoke plume that rises up the screen</span></td>
       </tr>
       <tr>
-        <td><span class="notranslate"><span class="inline">ef_snow</span></td>
+        <td><span class="inline">ef_snow</span></td>
         <td style="text-align: center"><img alt="snow effect example" class="icon" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Drawing/ef_snow.png" /></td>
         <td><span class="notranslate">An effect that generates multiple snow particles falling down the screen</span></td>
       </tr>
       <tr>
-        <td><span class="notranslate"><span class="inline">ef_spark</span></td>
+        <td><span class="inline">ef_spark</span></td>
         <td style="text-align: center"><img alt="spark effect example" class="icon" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Drawing/ef_spark.png" /></td>
         <td><span class="notranslate">An effect that generates a small spark</span></td>
       </tr>
       <tr>
-        <td><span class="notranslate"><span class="inline">ef_star</span></td>
+        <td><span class="inline">ef_star</span></td>
         <td style="text-align: center"><img alt="star effect example" class="icon" src="../../../../assets/Images/Scripting_Reference/GML/Reference/Drawing/ef_star.png" /></td>
         <td><span class="notranslate">An effect that generates star particles</span></td>
       </tr>

--- a/Manual/contents/GameMaker_Language/GML_Reference/General_Game_Control/game_id.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/General_Game_Control/game_id.htm
@@ -14,7 +14,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">game_id</span> <span data-conref="..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">game_id</span> <span data-conref="../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>この<b>読み取り専用</b>変数は、作成したゲームの一意な識別子を返します。ユニークなファイル名が必要な場合や、ゲームだけを識別する何かが必要な場合に使用できます。これは<a href="../../../Settings/Game_Options.htm">ゲームオプションで</a>設定することができます。</p>
   <p> </p>
   <h4>構文です。</h4>

--- a/Manual/contents/GameMaker_Language/GML_Reference/General_Game_Control/game_load.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/General_Game_Control/game_load.htm
@@ -14,7 +14,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">game_load</span> <span data-conref="..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">game_load</span> <span data-conref="../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>この機能を使うと、過去にセーブしたゲームをロードすることができます。 <a href="game_save.htm"><span class="inline">game_save()</span></a>.ただし、保存に使用されたバージョンを復元するので、それ以降に行われた更新は表示されないことに注意してください。詳しくは <a href="game_save.htm"><span class="inline">game_save()</span></a>.</p>
   <p> </p>
   <h4>構文です。</h4>

--- a/Manual/contents/GameMaker_Language/GML_Reference/General_Game_Control/game_save.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/General_Game_Control/game_save.htm
@@ -14,7 +14,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">game_save</span> <span data-conref="..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">game_save</span> <span data-conref="../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>これは、ゲームの現在の状態を保存するために使用できるレガシー関数であり、もう使用することは推奨されません。特定のゲームデータのみを保存、読み込みするカスタムセーブシステムを作成する場合は、代わりに<a href="../File_Handling/File_Handling.htm">ファイル関数を</a>使用してください。</p>
   <p>この関数は、ゲームの状態をそのまま保存しますが、その時点で使用されている動的なリソース（データ構造、サーフェス、<span class="notranslate">assets</span> で追加された<span class="notranslate">runtime</span> など）は保存されません。このようなセーブファイルをロードすると、セーブを作成するために使用したゲームのバージョンを復元するため、セーブ後に行われたゲームの更新は表示されません。</p>
   <p>なお、この機能で作成されたセーブファイルは、アップデートされた<a class="glossterm" data-glossterm="ランタイム" href="#">ランタイムバージョンに</a>対応しない場合がありますので、今後の<span class="notranslate">GameMaker</span> のアップデート、および上記の理由によりご自身のゲームのアップデートを行う際には、この機能を新しいセーブシステムに置き換えることが不可欠となります。</p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Movement_And_Collisions/Collisions/position_change.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Movement_And_Collisions/Collisions/position_change.htm
@@ -14,7 +14,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">position_change</span> <span data-conref="..\..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">position_change</span> <span data-conref="../../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>この関数は、ある位置で指定した地点の<i>インスタンスとの</i>衝突をチェックし、衝突があった場合は、衝突している<b>すべての</b>インスタンスを、選択したインスタンスに変更します<span class="notranslate">object</span> 。perf &quot;引数を <span class="inline">true</span> に設定すると、<span data-keyref="GameMaker Name">GameMaker は</span>見つかったインスタンスの<strong>Destroy</strong>と<strong>Clean Up</strong>イベント、および新しいインスタンスの<strong>Create</strong>イベントを実行します。また、 <span class="inline">false</span> に設定すると、これらのイベントを一切実行しません。Destroy、Clean Up、Create イベントを実行しない場合、create イベントで通常定義される変数を使用するインスタンスが作成されると、その変数が存在しなくなるため、ゲームがクラッシュすることに注意してください。</p>
   <p> </p>
   <h4>構文です。</h4>

--- a/Manual/contents/GameMaker_Language/GML_Reference/OS_And_Compiler/os_device.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/OS_And_Compiler/os_device.htm
@@ -14,7 +14,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">os_device</span> <span data-conref="..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">os_device</span> <span data-conref="../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>この<strong>読み取り専用</strong>変数は、以下に示す様々な定数値のうちの1つを保持し、現在どのデバイスでゲームを実行しているのかを知らせます。この変数は非推奨であることに注意してください。 <a href="os_get_info.htm"><span class="inline">os_get_info()</span></a>これは、ゲームを実行しているデバイスに関するより正確な情報を返します。</p>
   <p> </p>
   <h4>構文です。</h4>
@@ -36,43 +36,43 @@
         <th>商品説明</th>
       </tr>
       <tr>
-        <td><span class="notranslate"><span class="inline">device_ios_ipad</span></td>
+        <td><span class="inline">device_ios_ipad</span></td>
         <td>iPad</td>
       </tr>
       <tr>
-        <td><span class="notranslate"><span class="inline">device_ios_ipad_retina</span></td>
+        <td><span class="inline">device_ios_ipad_retina</span></td>
         <td>Retinaディスプレイサイズ2048×1536の新型iPad</td>
       </tr>
       <tr>
-        <td><span class="notranslate"><span class="inline">device_ios_iphone6</span></td>
+        <td><span class="inline">device_ios_iphone6</span></td>
         <td>iPhone6、ディスプレイサイズ1334×750</td>
       </tr>
       <tr>
-        <td><span class="notranslate"><span class="inline">device_ios_iphone6plus</span></td>
+        <td><span class="inline">device_ios_iphone6plus</span></td>
         <td>ディスプレイ1920×1080でより大きくなったiPhone6</td>
       </tr>
       <tr>
-        <td><span class="notranslate"><span class="inline">device_ios_iphone5</span></td>
+        <td><span class="inline">device_ios_iphone5</span></td>
         <td>iPhone5、ディスプレイサイズ640×1136)</td>
       </tr>
       <tr>
-        <td><span class="notranslate"><span class="inline">device_ios_iphone</span></td>
+        <td><span class="inline">device_ios_iphone</span></td>
         <td>旧型のiPhone/iPod Touch（画面サイズ480×320）<i>または</i> <span class="notranslate">Android</span> 携帯電話</td>
       </tr>
       <tr>
-        <td><span class="notranslate"><span class="inline">device_ios_iphone_retina</span></td>
+        <td><span class="inline">device_ios_iphone_retina</span></td>
         <td>960 x 640のRetinaディスプレイを搭載した新しいiPhone/iPod Touch</td>
       </tr>
       <tr>
-        <td><span class="notranslate"><span class="inline">device_emulator</span></td>
+        <td><span class="inline">device_emulator</span></td>
         <td>デバイスの正体はエミュレータ（<span class="notranslate">Windows Phone</span> または<span class="notranslate">Android</span> ）です。</td>
       </tr>
       <tr>
-        <td><span class="notranslate"><span class="inline">device_tablet</span></td>
+        <td><span class="inline">device_tablet</span></td>
         <td>Androidタブレット</td>
       </tr>
       <tr>
-        <td><span class="notranslate"><span class="inline">device_ios_unknown</span></td>
+        <td><span class="inline">device_ios_unknown</span></td>
         <td>不明またはiOSではない</td>
       </tr>
     </tbody>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/array_height_2d.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/array_height_2d.htm
@@ -15,7 +15,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">array_height_2d</span> <span data-conref="..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">array_height_2d</span> <span data-conref="../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p class="note"><b>警告!こ</b>の関数は、配列が1次元または2次元に限定されなくなったため、非推奨（ <span class="inline"><a href="array_length.htm">array_length()</a></span> ）となっています。したがって、この関数はレガシープロジェクトのサポートのためにのみ提供されています。すべての新しいプロジェクトは、多次元配列の作成とアクセスに現在の方法を使用する必要があります（詳しくは<a href="../../GML_Overview/Arrays.htm">ここを</a>参照してください）。</p>
   <p>この関数を使うと、2次元配列の1次元目の高さ（エントリ数）を得ることができます。チェックする配列を指定すると、その配列が何個の初期エントリを含んでいるかが出力されます。配列の 2 次元のエントリ数を得るには，関数 <a href="array_length_2d.htm"><span class="inline">array_length_2d</span></a>.</p>
   <p> </p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/array_length_1d.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/array_length_1d.htm
@@ -15,7 +15,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">array_length_1d</span> <span data-conref="..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">array_length_1d</span> <span data-conref="../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p class="note"><b>警告!こ</b>の関数は、配列が1次元または2次元に限定されなくなったため、非推奨（ <span class="inline"><a href="array_length.htm">array_length()</a></span> ）となっています。したがって、この関数はレガシープロジェクトのサポートのためにのみ提供されています。すべての新しいプロジェクトは、多次元配列の作成とアクセスに現在の方法を使用する必要があります（詳しくは<a href="../../GML_Overview/Arrays.htm">ここを</a>参照してください）。</p>
   <p>この関数を使うと、1次元配列の長さ（エントリ数）を得ることができます。2 次元配列の場合は，関数 <a href="array_height_2d.htm"><span class="inline">array_height_2d</span></a>と <a href="array_length_2d.htm"><span class="inline">array_length_2d</span></a>関数を使用します。</p>
   <p class="note"><b>重要!配 </b>列が 32,000 個以上のエントリを持つ場合、この関数は誤った値を返しますので使用しないでください。</p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/array_length_2d.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/array_length_2d.htm
@@ -15,7 +15,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">array_length_2d</span> <span data-conref="..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">array_length_2d</span> <span data-conref="../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p class="note"><b>警告!こ</b>の関数は、配列が1次元または2次元に限定されなくなったため、非推奨（ <span class="inline"><a href="array_length.htm">array_length()</a></span> ）となっています。したがって、この関数はレガシープロジェクトのサポートのためにのみ提供されています。すべての新しいプロジェクトは、多次元配列の作成とアクセスに現在の方法を使用する必要があります（詳しくは<a href="../../GML_Overview/Arrays.htm">ここを</a>参照してください）。</p>
   <p>この関数を使うと、配列の2次元目の長さ（エントリ数）を求めることができます。1 次元のエントリ番号を指定すると、この関数はその配列が持つ 2 次元のエントリ数を返します（1 次元の長さを求めるには、この関数を使用します）。 <a href="array_height_2d.htm"><span class="inline">array_height_2D()</span></a>).この関数は、与えられた変数が配列でない場合は0を、1次元配列の場合は1を返します（まだ1行あるため）。</p>
   <p> </p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Web_And_HTML5/analytics_event.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Web_And_HTML5/analytics_event.htm
@@ -14,7 +14,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">analytics_event</span> <span data-conref="..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">analytics_event</span> <span data-conref="../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>この関数は、<a href="../../../Settings/Game_Options/HTML5.htm">HTML5ゲームオプションで</a>設定した分析プロバイダーに、指定されたテキストを送信します。この関数は、使用しているプロバイダーの範囲外のものを追跡するためのカスタム分析を作成するために使用することができる。</p>
   <p> </p>
   <h4>構文です。</h4>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Web_And_HTML5/analytics_event_ext.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Web_And_HTML5/analytics_event_ext.htm
@@ -14,7 +14,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">analytics_event_ext</span> <span data-conref="..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">analytics_event_ext</span> <span data-conref="../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>この関数は、<a href="../../../Settings/Game_Options/HTML5.htm">HTML5ゲームオプションで</a>設定した分析プロバイダーに、指定されたテキストを送信します。この関数は、何かを追跡するためのカスタム分析を作成するために使用することができます。
     また、カスタムパラメータ/値ペアを受け付けます。パラメータは<span class="notranslate">string</span> で、値は実数です。Google Analyticsの場合、追加できるペアは1つだけですが、Flurryの場合は最大で
     7.</p>


### PR DESCRIPTION
This PR contains more changes for: 

* https://github.com/YoYoGames/GameMaker-Manual/issues/334

Fixed the slashes leading to the tag not showing properly on pages.